### PR TITLE
Fixes documentation

### DIFF
--- a/lib/build.gradle.kts
+++ b/lib/build.gradle.kts
@@ -42,7 +42,6 @@ dependencies {
 }
 
 tasks.withType<DokkaTask>().configureEach {
-  dependsOn("copyDocumentationImages")
   dokkaSourceSets {
     named("main") {
       moduleName.set("Nostrino Nostr SDK")

--- a/lib/module.md
+++ b/lib/module.md
@@ -1,1 +1,3 @@
+# Module Nostrino
+
 TODO


### PR DESCRIPTION
- Sets markdown header in `module.md` per [documentation](https://kotlinlang.org/docs/dokka-module-and-package-docs.html)
- Removes unavailable dependent task `copyDocumentationImages`. We can add this back in once we have a logo.
- Sets documentation to build on all branches