### PR TITLE
Exposes variable to check whether Event has a valid signature

### DIFF
--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -349,6 +349,7 @@ public final class app/cash/nostrino/model/Event {
 	public final fun getPubKey ()Lokio/ByteString;
 	public final fun getSig ()Lokio/ByteString;
 	public final fun getTags ()Ljava/util/List;
+  public final fun getValid ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/lib/api/lib.api
+++ b/lib/api/lib.api
@@ -349,7 +349,7 @@ public final class app/cash/nostrino/model/Event {
 	public final fun getPubKey ()Lokio/ByteString;
 	public final fun getSig ()Lokio/ByteString;
 	public final fun getTags ()Ljava/util/List;
-  public final fun getValid ()Z
+	public final fun getValidSignature ()Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/lib/src/main/kotlin/app/cash/nostrino/model/Event.kt
+++ b/lib/src/main/kotlin/app/cash/nostrino/model/Event.kt
@@ -19,6 +19,7 @@ package app.cash.nostrino.model
 import app.cash.nostrino.crypto.CipherText
 import app.cash.nostrino.message.NostrMessageAdapter.Companion.moshi
 import com.squareup.moshi.Json
+import fr.acinq.secp256k1.Secp256k1
 import okio.ByteString
 import java.time.Instant
 
@@ -34,6 +35,13 @@ data class Event(
   val content: String,
   val sig: ByteString
 ) {
+
+  /**
+   * Valid is `true` if the event has a valid signature.
+   */
+  val valid: Boolean by lazy {
+    Secp256k1.verifySchnorr(sig.toByteArray(), id.toByteArray(), pubKey.toByteArray())
+  }
 
   /**
    * Deserialise the `content` string into an instance of `EventContent` that corresponds with the event `kind`.

--- a/lib/src/main/kotlin/app/cash/nostrino/model/Event.kt
+++ b/lib/src/main/kotlin/app/cash/nostrino/model/Event.kt
@@ -39,7 +39,7 @@ data class Event(
   /**
    * Valid is `true` if the event has a valid signature.
    */
-  val valid: Boolean by lazy {
+  val validSignature: Boolean by lazy {
     Secp256k1.verifySchnorr(sig.toByteArray(), id.toByteArray(), pubKey.toByteArray())
   }
 

--- a/lib/src/test/kotlin/app/cash/nostrino/model/EventTest.kt
+++ b/lib/src/test/kotlin/app/cash/nostrino/model/EventTest.kt
@@ -16,6 +16,9 @@
 
 package app.cash.nostrino.model
 
+import app.cash.nostrino.crypto.SecKeyGenerator
+import app.cash.nostrino.message.NostrMessageAdapter
+import app.cash.nostrino.message.NostrMessageAdapter.Companion.moshi
 import app.cash.nostrino.model.EncryptedDmTest.Companion.arbEncryptedDm
 import app.cash.nostrino.model.Primitives.arbByteString32
 import app.cash.nostrino.model.Primitives.arbByteString64
@@ -29,6 +32,7 @@ import io.kotest.property.Arb
 import io.kotest.property.arbitrary.bind
 import io.kotest.property.arbitrary.choice
 import io.kotest.property.arbitrary.map
+import io.kotest.property.arbitrary.next
 import io.kotest.property.checkAll
 
 class EventTest : StringSpec({
@@ -37,6 +41,31 @@ class EventTest : StringSpec({
     checkAll(arbEventWithContent) { (event, content) ->
       event.content() shouldBe content
     }
+  }
+
+  "signed event has valid signature" {
+    val sec = SecKeyGenerator().generate()
+    val note = arbTextNote.next()
+    val event = note.sign(sec)
+
+    event.valid shouldBe true
+  }
+
+  "parsed event has valid signature" {
+    val rawEvent = """
+      {
+        "content": "Sorry it took us so long to get here, but we thought our sweet npub would be worth the wait.",
+        "created_at": 1684358892,
+        "id": "32157d937c68c3f2d66809ac475577f27aee05c3b3bc1f061c70d24b7481005f",
+        "kind": 1,
+        "pubkey": "c7617e84337c611c7d5f941b35b1ec51f2ae6e9f41aac9616092d510e1c295e0",
+        "sig": "e68306cecbb9934521d1039c849970f968b3d9db67b0790bf66ac089e6039079e876ffb428c09bcb609a7b0379d3cf2a69bc26494c6003ee9d3d40a7926b5eb8",
+        "tags": []
+      }
+    """.trimIndent()
+    val event = moshi.adapter(Event::class.java).fromJson(rawEvent)
+
+    event?.valid shouldBe true
   }
 }) {
   companion object {


### PR DESCRIPTION
Adds `valid` to `Event`, exposing whether the event has a valid signature.

Uses `by lazy` to verify only when called, and persist the result thereafter.