### PR TITLE
Allow HashTag event consumption test to run against relay with existing events

### DIFF
--- a/lib/src/test/kotlin/app/cash/nostrino/client/RelayClientTest.kt
+++ b/lib/src/test/kotlin/app/cash/nostrino/client/RelayClientTest.kt
@@ -21,16 +21,22 @@ import app.cash.nostrino.crypto.SecKeyGenerator
 import app.cash.nostrino.model.EncryptedDm
 import app.cash.nostrino.model.Filter
 import app.cash.nostrino.model.HashTag
+import app.cash.nostrino.model.Primitives.arbByteString32
 import app.cash.nostrino.model.ReactionTest.Companion.arbReaction
+import app.cash.nostrino.model.TagTest.Companion.arbHashTag
 import app.cash.nostrino.model.TextNote
 import app.cash.nostrino.model.TextNoteTest.Companion.arbTextNote
 import app.cash.nostrino.model.UserMetaDataTest.Companion.arbUserMetaData
+import app.cash.nostrino.model.UserMetaDataTest.Companion.arbVanillaString
 import app.cash.turbine.test
 import io.kotest.assertions.fail
 import io.kotest.core.spec.style.StringSpec
 import io.kotest.matchers.ints.shouldBeLessThan
 import io.kotest.matchers.shouldBe
+import io.kotest.property.Arb
+import io.kotest.property.arbitrary.map
 import io.kotest.property.arbitrary.next
+import io.kotest.property.arbitrary.set
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -159,24 +165,14 @@ class RelayClientTest : StringSpec({
   "can consume events by hashtag" {
     val sec = SecKeyGenerator().generate()
     val noteWithoutHashTags = arbTextNote.next()
-    val noteWithHashTags = TextNote(
-      text = "never",
-      tags = listOf(
-        HashTag("gonna"),
-        HashTag("give"),
-        HashTag("you"),
-        HashTag("up")
-      )
-    )
+    val tags = Arb.set(arbHashTag, 4).next().toList()
+    val noteWithHashTags = arbTextNote.next().copy(tags = tags)
 
     with(RelayClient("ws://localhost:7707")) {
       start()
       subscribe(
         Filter.hashTagNotes(
-          hashtags = setOf(
-            HashTag("give"),
-            HashTag("up"),
-          )
+          hashtags = setOf(tags[1], tags[3])
         )
       )
 
@@ -185,7 +181,7 @@ class RelayClientTest : StringSpec({
 
       notes.test {
         val actualEvent = awaitItem()
-        actualEvent.content shouldBe "never"
+        actualEvent.content shouldBe noteWithHashTags.text
         actualEvent.content() shouldBe noteWithHashTags
 
         expectNoEvents()


### PR DESCRIPTION
This test had been failing because it found events that were existing from a previous test run.

