### PR TITLE
Prepare for release 0.0.7.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,18 @@
 
 ## [Unreleased]
 
+## [0.0.7] - 2026-07-31
+
 ### Added
 * NIP-44 Versioned Encrypted Direct Messages with ChaCha20 and HMAC-SHA256 (Jem Mawson)
+* Kotlin Multiplatform support: JVM, iOS (x64, arm64, simulator arm64) and Linux x64 targets (Jose Mateo)
+* Multiplatform `PubKey`, `SecKey` and `SecKeyGenerator` (Jose Mateo)
+* Relay messages and connection state exposed as flows on `RelayClient` (Jose Mateo)
+* Random subscription IDs used by default in `Relay` (Jem Mawson)
+
+### Changed
+* JVM target raised to 11 (Jem Mawson)
+* JSON adapters restructured into a protocol/serde layer; relay message types now use enums instead of string literals (Jem Mawson)
 
 
 ## [0.0.6] - 2023-07-26

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.nostrino
-VERSION_NAME=0.0.7-SNAPSHOT
+VERSION_NAME=0.0.7
 POM_URL=https://github.com/cashapp/nostrino/
 POM_SCM_URL=https://github.com/cashapp/nostrino/
 POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/nostrino.git

--- a/lib-test/src/test/kotlin/app/cash/nostrino/client/RelaySetTest.kt
+++ b/lib-test/src/test/kotlin/app/cash/nostrino/client/RelaySetTest.kt
@@ -89,7 +89,7 @@ class RelaySetTest : StringSpec({
   }
 
   "merge distinct events into a single flow" {
-    val events = Arb.list(arbEvent, 20..20).next().distinct().take(6)
+    val events = Arb.list(arbEvent, 20..20).next().distinctBy { it.id }.take(6)
     val set = RelaySet(
       setOf(
         FakeRelay(events.take(2).toMutableList()),
@@ -103,7 +103,7 @@ class RelaySetTest : StringSpec({
   }
 
   "merge duplicate events into a single flow" {
-    val events = Arb.list(arbEvent, 20..20).next().distinct().take(6).toMutableList()
+    val events = Arb.list(arbEvent, 20..20).next().distinctBy { it.id }.take(6).toMutableList()
     val set = RelaySet(
       setOf(
         FakeRelay(events),
@@ -115,7 +115,7 @@ class RelaySetTest : StringSpec({
   }
 
   "merge partially overlapping events into a single flow" {
-    val events = Arb.list(arbEvent, 20..20).next().distinct().take(6).toMutableList()
+    val events = Arb.list(arbEvent, 20..20).next().distinctBy { it.id }.take(6).toMutableList()
     val set = RelaySet(
       setOf(
         FakeRelay(events.take(4).toMutableList()),
@@ -135,7 +135,7 @@ class RelaySetTest : StringSpec({
   }
 
   "merge relay messages into a single flow" {
-    val events = Arb.list(arbEvent, 20..20).next().distinct().take(6).toMutableList()
+    val events = Arb.list(arbEvent, 20..20).next().distinctBy { it.id }.take(6).toMutableList()
     val set = RelaySet(
       setOf(
         FakeRelay(events),


### PR DESCRIPTION
Release 0.0.7 — first release since 0.0.6 (2023-07-26). Headline changes (see CHANGELOG.md):

- NIP-44 v2 encryption (encrypt/decrypt, conversation keys, test vectors)
- Kotlin Multiplatform support (JVM, iOS, Linux)
- Relay client improvements (random subscription IDs, flow-based relay API)
- JVM 11 target

Validated locally with a full build including dockerized relay integration tests (`bin/gradle build` → BUILD SUCCESSFUL).

Per RELEASING.md: after this merges, trigger the [Publish a release](https://github.com/block/nostrino/actions/workflows/Release.yml) workflow for tag `nostrino-0.0.7`.