### PR TITLE
Prepare next development version.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=app.cash.nostrino
-VERSION_NAME=0.0.7
+VERSION_NAME=0.0.8-SNAPSHOT
 POM_URL=https://github.com/cashapp/nostrino/
 POM_SCM_URL=https://github.com/cashapp/nostrino/
 POM_SCM_CONNECTION=scm:git:git://github.com/cashapp/nostrino.git


### PR DESCRIPTION
Bump version to 0.0.8-SNAPSHOT following the 0.0.7 release, per RELEASING.md.